### PR TITLE
Remove thumbnail borders and clean unused imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import Hero from './components/Hero';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cpu, Mail, Phone, MapPin, Facebook, Twitter, Linkedin, Instagram } from 'lucide-react';
+import { Mail, Phone, MapPin, Facebook, Twitter, Linkedin, Instagram } from 'lucide-react';
 
 const Footer: React.FC = () => {
   const scrollToSection = (sectionId: string) => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Menu, X, Cpu } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 interface HeaderProps {
   activeSection: string;

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Zap, BarChart3, Smartphone, Brain, MessageSquare, Wrench } from 'lucide-react';
+import { Zap, BarChart3, Smartphone, Brain, MessageSquare } from 'lucide-react';
 
 const Services: React.FC = () => {
   const services = [

--- a/src/pages/AutomatizacionPage.tsx
+++ b/src/pages/AutomatizacionPage.tsx
@@ -62,7 +62,7 @@ const AutomatizacionPage: React.FC = () => {
               <img
                 src={card.imagen}
                 alt={card.titulo}
-                className="w-28 h-28 object-cover rounded-xl mb-4 border-4 border-blue-200 shadow-inner bg-gray-50"
+                className="w-28 h-28 object-cover rounded-xl mb-4"
               />
               <h2 className="text-2xl font-bold mb-1 text-center text-gradient bg-gradient-to-r from-blue-500 to-green-400 bg-clip-text text-transparent drop-shadow">
                 {card.titulo}


### PR DESCRIPTION
## Summary
- Remove borders and background styling from thumbnails in `AutomatizacionPage`
- Clean unused imports across components to pass lint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f05c6651c8328a5a93019b4e5f47a